### PR TITLE
Add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd swifft
 cargo build --release
 ```
 
-## Usage
+## Usage (TODO test it)
 ```rust
 use swifft::{Block, Key, State, BLOCK_LEN, KEY_LEN};
 
@@ -35,6 +35,16 @@ let block = Block::from(block_bytes);
 
 // Compress in-place, writing the new state back into `state`.
 state.compress(&key, &block);
+```
+## Example
+There is a runnable version of this snippet in `examples/naive.rs`:
+
+```bash
+cargo run --example naive
+```
+It prints the resulting 72-byte SWIFFT digest in hex.
+```
+SWIFFT digest (hex): b4064d836d08c690362a48021db5960912bbf24d1e5f2239b19aebb459bbc974e0355afa89bc40ae93ed0064886c33bd3c40d36f3d6bb3eb9dfddb37c39f4d2b0000000000040000
 ```
 
 ## Project structure

--- a/examples/naive.rs
+++ b/examples/naive.rs
@@ -1,0 +1,44 @@
+use std::fmt::Write;
+
+use swifft::{Block, Key, State, BLOCK_LEN, KEY_LEN};
+
+fn main() {
+    let key = demo_key();
+    let block = demo_block();
+
+    let mut state = State::default();
+    compress_and_print(&mut state, &key, &block);
+}
+
+fn demo_key() -> Key {
+    Key::from(patterned::<KEY_LEN>(11, 7))
+}
+
+fn demo_block() -> Block {
+    Block::from(patterned::<BLOCK_LEN>(5, 3))
+}
+
+fn compress_and_print(state: &mut State, key: &Key, block: &Block) {
+    state.compress(key, block);
+    println!("SWIFFT digest (hex): {}", to_hex(state.as_bytes()));
+}
+
+fn patterned<const LEN: usize>(multiplier: u8, addend: u8) -> [u8; LEN] {
+    let mut bytes = [0u8; LEN];
+    fill_pattern(&mut bytes, multiplier, addend);
+    bytes
+}
+
+fn fill_pattern(bytes: &mut [u8], multiplier: u8, addend: u8) {
+    for (i, byte) in bytes.iter_mut().enumerate() {
+        *byte = (i as u8).wrapping_mul(multiplier).wrapping_add(addend);
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(out, "{:02x}", b);
+    }
+    out
+}


### PR DESCRIPTION
Closes #4 

- Added a runnable example at examples/naive.rs that builds patterned key/block data, compresses a state, and prints the digest, structured with small helpers (demo_key, demo_block, compress_and_print, patterned/fill_pattern, to_hex) for clarity/DRY.

- Updated README.md to point to the example name change and how to run it (cargo run --example naive), noting the hex digest output.